### PR TITLE
Fixed regex pattern and removed hardcoded enums

### DIFF
--- a/aws-applicationinsights-application/aws-applicationinsights-application.json
+++ b/aws-applicationinsights-application/aws-applicationinsights-application.json
@@ -99,7 +99,7 @@
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 128,
-                    "pattern": "^[\\d\\w-_.+]*$"
+                    "pattern": "^[\\d\\w\\-_.+]*$"
                 },
                 "ResourceList": {
                     "description": "The list of resource ARNs that belong to the component.",
@@ -183,7 +183,7 @@
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 128,
-                    "pattern": "^[\\d\\w-_.+]*$"
+                    "pattern": "^[\\d\\w\\-_.+]*$"
                 },
                 "ComponentARN": {
                     "description": "The ARN of the compnonent.",
@@ -195,19 +195,7 @@
                 "Tier": {
                     "description": "The tier of the application component.",
                     "type": "string",
-                    "enum": [
-                        "DOT_NET_WORKER",
-                        "DOT_NET_WEB",
-                        "DOT_NET_CORE",
-                        "SQL_SERVER",
-                        "SQL_SERVER_ALWAYSON_AVAILABILITY_GROUP",
-                        "MYSQL",
-                        "POSTGRESQL",
-                        "DEFAULT",
-                        "CUSTOM",
-                        "JAVA_JMX",
-                        "ORACLE"
-                    ]
+		    "pattern": "^[A-Z][[A-Z]_]*$"
                 },
                 "ComponentConfigurationMode": {
                     "description": "The component monitoring configuration mode.",
@@ -385,22 +373,7 @@
                 "LogType": {
                     "description": "The log type decides the log patterns against which Application Insights analyzes the log.",
                     "type": "string",
-                    "enum": [
-                        "SQL_SERVER",
-                        "MYSQL",
-                        "MYSQL_SLOW_QUERY",
-                        "POSTGRESQL",
-                        "IIS",
-                        "APPLICATION",
-                        "WINDOWS_EVENTS",
-                        "WINDOWS_EVENTS_GENERIC_ERRORS",
-                        "SQL_SERVER_ALWAYSON_AVAILABILITY_GROUP",
-                        "DEFAULT",
-                        "CUSTOM",
-                        "STEP_FUNCTION",
-                        "API_GATEWAY_ACCESS",
-                        "API_GATEWAY_EXECUTION"
-                    ]
+		    "pattern": "^[A-Z][[A-Z]_]*$"
                 },
                 "Encoding": {
                     "description": "The type of encoding of the logs to be monitored.",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Changed regex for component names from `^[\d\w-_.+]*$` to `^[\d\w\-_.+]*$`. This was needed since the use of `-` in the first context was incorrect and needed to be escaped
* Also removed the variable enums for `Tier` and `LogType`. The current recommendation from CFN team is to not have large enum lists that need to be updated. Instead, I changed to use regex, which validates the previous enum structure: Capital letters and underscores only, with a starting capital letter. I tested all the existing enums against the new regex too.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
