### PR TITLE
make HANAPrometheusExporter property required

### DIFF
--- a/aws-applicationinsights-application/aws-applicationinsights-application.json
+++ b/aws-applicationinsights-application/aws-applicationinsights-application.json
@@ -385,6 +385,12 @@
                     "type": "string"
                 }
             },
+            "required": [
+                "HANASID",
+                "HANAPort",
+                "HANASecretName",
+                "AgreeToInstallHANADBClient"
+            ],
             "additionalProperties": false
         },
         "HAClusterPrometheusExporter": {


### PR DESCRIPTION
*Issue #, if available:*
Make HANAPrometheusExporter configuration required.
 
*Description of changes:*
HANAPrometheusExporter requires few porperty and this will throw error well before applicaiton is created. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
